### PR TITLE
Problem with options handling

### DIFF
--- a/Rasterizer.php
+++ b/Rasterizer.php
@@ -125,8 +125,8 @@ class Rasterizer
         $builder = new ProcessBuilder();
         $options = array();
 
-        foreach ($this->config['phantomjs']['options'] as $name => $value) {
-            $options[] = sprintf('%s="%s"', $name, $value);
+        foreach ($this->config['phantomjs']['options'] as $option) {
+            $options[] = $option;
         }
 
         $builder
@@ -162,4 +162,4 @@ class Rasterizer
 
         return $content;
     }
-} 
+}


### PR DESCRIPTION
I was unable to correctly pass an option to phantomjs.
I opted to append the configured options verbatim to the command line.

Options example in config.yml:

```
phantomjs:
    callable: %kernel.root_dir%/../bin/phantomjs
    options: ["--ignore-ssl-errors=true"]
```
