### PR TITLE
Symfony 5 support: Return 'assets' dir correctly

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -55,10 +55,10 @@ class Configuration implements ConfigurationInterface
     private function getAssetsDir()
     {
         switch (Kernel::MAJOR_VERSION) {
-            case 4:
-                return 'assets';
-            default:
+            case 3:
                 return 'web';
+            default:
+                return 'assets';
         }
     }
 }


### PR DESCRIPTION
By default, return 'assets' for anything above Symfony 4. Previously, it was incorrectly returning 'web' for Symfony 5.