### PR TITLE
Update method to pass HTML in Puppeteer provider

### DIFF
--- a/Resources/docs/provider/puppeteer.md
+++ b/Resources/docs/provider/puppeteer.md
@@ -22,11 +22,7 @@ const format = args[2];
     });
     const page = await browser.newPage();
 
-    // https://github.com/GoogleChrome/puppeteer/issues/728
-    // await page.setContent(html);
-    // await page.waitForNavigation({ waitUntil: 'networkidle0' });
-
-    await page.goto('data:text/html,' + html, { waitUntil: 'networkidle0' });
+    await page.setContent(html, { waitUntil: 'networkidle0' });
 
     let buff = null;
 


### PR DESCRIPTION
The previous method used to pass HTML to the browser in the example Puppeteer provider truncates output if certain characters are present in the HTML, including `#` which is present in HTML entities. `page.setContent` has been able to accept a `waitUntil` option for the last couple of years so this is now an available approach.