### PR TITLE
Fix broken test coverage

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,2 @@
 service_name: travis-ci
-src_dir: .
 coverage_clover: build/logs/clover.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/*
+/build
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 
 php:
   - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ matrix:
   fast_finish: true
 
 before_script:
-  - composer update --dev
+  - composer update --no-interaction --no-suggest
 
-script: vendor/bin/phpunit
+script:
+  - composer test
 
 after_script:
-  - php vendor/bin/coveralls -v
+  - vendor/bin/coveralls -v
 
 notifications:
   email:

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,8 @@
         "phpunit/phpunit": "~6.0",
         "mockery/mockery": "~1.0",
         "satooshi/php-coveralls": "~1.0"
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit bootstrap="./Tests/bootstrap.php" colors="true">
-    <php>
-        <server name="KERNEL_DIR" value="./Tests/App/app" />
-    </php>
-
     <logging>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
@@ -14,4 +10,11 @@
             <directory suffix="Test.php">./Tests</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <file>ConfigHelper.php</file>
+            <file>Rasterizer.php</file>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
- Remove invalid key in Coveralls config
- Build folder should be ignored by git
- Remove deprecated --dev composer argument in Travis config
- Remove TravisCI composer suggestions output 
- Remove invalid server key in PHPUnit config
- Add PHPUnit whitelist to enable coverage output
- Add PHP 7.2, 7.3 and 7.4 to build matrix