### PR TITLE
Use correct TreeBuilder root node method for symfony/config version

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -14,8 +14,11 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('padam87_rasterize');
+        $rootNode = method_exists($treeBuilder, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('padam87_rasterize');
 
-        $treeBuilder->getRootNode()
+        $rootNode
             ->children()
                 ->arrayNode('script')
                     ->addDefaultsIfNotSet()


### PR DESCRIPTION
Symfony 3.4 does not have TreeBuilder::getRootNode. See issue #26 