### PR TITLE
Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         "psr-4": { "Padam87\\RasterizeBundle\\": "" }
     },
     "require": {
-        "php": "~7.1",
-        "symfony/process": "~3.3|~4.0|~5.0",
-        "symfony/stopwatch": "~2.3|~3.0|~4.0|~5.0"
+        "php": "^7.1 || ^8.0",
+        "symfony/process": "^4.0 || ^5.0 || ^6.0",
+        "symfony/stopwatch": "^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",


### PR DESCRIPTION
PHP8 and SF6 support, dropped SF3