### PR TITLE
Extension class from HttpKernel is deprecated and replace by DependencyInjection namespace

### DIFF
--- a/DependencyInjection/Padam87RasterizeExtension.php
+++ b/DependencyInjection/Padam87RasterizeExtension.php
@@ -5,7 +5,7 @@ namespace Padam87\RasterizeBundle\DependencyInjection;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration


### PR DESCRIPTION
Extension namespace change in Symfony 8.0 : https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php#L23

This change allow to remove a deprecated notice.